### PR TITLE
Set open_timeout and read_timeout on Net::HTTP

### DIFF
--- a/lib/brite_verify.rb
+++ b/lib/brite_verify.rb
@@ -5,4 +5,7 @@ require 'brite_verify/email'
 
 module BriteVerify
   HOST = "bpi.briteverify.com"
+
+  mattr_accessor(:open_timeout) { 4 }
+  mattr_accessor(:read_timeout) { 8 }
 end

--- a/lib/brite_verify/email_fetcher.rb
+++ b/lib/brite_verify/email_fetcher.rb
@@ -21,6 +21,8 @@ module BriteVerify
       uri              = verification_uri(address)
       http             = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl     = true
+      http.open_timeout = BriteVerify.open_timeout
+      http.read_timeout = BriteVerify.read_timeout
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       request          = Net::HTTP::Get.new(uri.request_uri)
       response         = http.request(request)


### PR DESCRIPTION
This PR sets more acceptable `open_timeout` and `read_timeout` values on requests to BriteVerify's servers.
The default value for `Net::HTTP` is 60s for each, which is too high. Heroku's request timeout for example is 30s.